### PR TITLE
Update all tables to use `Top` input parameter to correctly set default page size. Closes #5

### DIFF
--- a/microsoft365/table_microsoft365_calendar.go
+++ b/microsoft365/table_microsoft365_calendar.go
@@ -9,6 +9,7 @@ import (
 
 	msgraphcore "github.com/microsoftgraph/msgraph-sdk-go-core"
 	"github.com/microsoftgraph/msgraph-sdk-go/models"
+	"github.com/microsoftgraph/msgraph-sdk-go/users/item/calendargroups/item/calendars"
 )
 
 func calendarColumns() []*plugin.Column {
@@ -87,7 +88,22 @@ func listMicrosoft365Calendars(ctx context.Context, d *plugin.QueryData, h *plug
 	}
 	userID := d.KeyColumnQuals["user_id"].GetStringValue()
 
-	result, err := client.UsersById(userID).CalendarGroupsById(*groupData.GetId()).Calendars().Get(ctx, nil)
+	input := &calendars.CalendarsRequestBuilderGetQueryParameters{}
+
+	// Minimum value is 1 (this function isn't run if "limit 0" is specified)
+	// Maximum value is unknown (tested up to 9999)
+	pageSize := int64(9999)
+	limit := d.QueryContext.Limit
+	if limit != nil && *limit < pageSize {
+		pageSize = *limit
+	}
+	input.Top = Int32(int32(pageSize))
+
+	options := &calendars.CalendarsRequestBuilderGetRequestConfiguration{
+		QueryParameters: input,
+	}
+
+	result, err := client.UsersById(userID).CalendarGroupsById(*groupData.GetId()).Calendars().Get(ctx, options)
 	if err != nil {
 		errObj := getErrorObject(err)
 		return nil, errObj

--- a/microsoft365/table_microsoft365_calendar_group.go
+++ b/microsoft365/table_microsoft365_calendar_group.go
@@ -9,6 +9,7 @@ import (
 
 	msgraphcore "github.com/microsoftgraph/msgraph-sdk-go-core"
 	"github.com/microsoftgraph/msgraph-sdk-go/models"
+	"github.com/microsoftgraph/msgraph-sdk-go/users/item/calendargroups"
 )
 
 func calendarGroupColumns() []*plugin.Column {
@@ -67,7 +68,22 @@ func listMicrosoft365CalendarGroups(ctx context.Context, d *plugin.QueryData, _ 
 	}
 	userID := d.KeyColumnQuals["user_id"].GetStringValue()
 
-	result, err := client.UsersById(userID).CalendarGroups().Get(ctx, nil)
+	input := &calendargroups.CalendarGroupsRequestBuilderGetQueryParameters{}
+
+	// Minimum value is 1 (this function isn't run if "limit 0" is specified)
+	// Maximum value is unknown (tested up to 9999)
+	pageSize := int64(9999)
+	limit := d.QueryContext.Limit
+	if limit != nil && *limit < pageSize {
+		pageSize = *limit
+	}
+	input.Top = Int32(int32(pageSize))
+
+	options := &calendargroups.CalendarGroupsRequestBuilderGetRequestConfiguration{
+		QueryParameters: input,
+	}
+
+	result, err := client.UsersById(userID).CalendarGroups().Get(ctx, options)
 	if err != nil {
 		errObj := getErrorObject(err)
 		return nil, errObj

--- a/microsoft365/table_microsoft365_contact.go
+++ b/microsoft365/table_microsoft365_contact.go
@@ -108,9 +108,7 @@ func listMicrosoft365Contacts(ctx context.Context, d *plugin.QueryData, _ *plugi
 	if limit != nil && *limit < pageSize {
 		pageSize = *limit
 	}
-
-	pageSize32 := int32(pageSize)
-	input.Top = &pageSize32
+	input.Top = Int32(int32(pageSize))
 
 	options := &contacts.ContactsRequestBuilderGetRequestConfiguration{
 		QueryParameters: input,

--- a/microsoft365/table_microsoft365_drive.go
+++ b/microsoft365/table_microsoft365_drive.go
@@ -85,6 +85,15 @@ func listMicrosoft365Drives(ctx context.Context, d *plugin.QueryData, _ *plugin.
 
 	input := &drives.DrivesRequestBuilderGetQueryParameters{}
 
+	// Minimum value is 1 (this function isn't run if "limit 0" is specified)
+	// Maximum value is unknown (tested up to 9999)
+	pageSize := int64(9999)
+	limit := d.QueryContext.Limit
+	if limit != nil && *limit < pageSize {
+		pageSize = *limit
+	}
+	input.Top = Int32(int32(pageSize))
+
 	var queryFilter string
 	equalQuals := d.KeyColumnQuals
 	filter := buildDriveQueryFilter(equalQuals)

--- a/microsoft365/table_microsoft365_mail_message.go
+++ b/microsoft365/table_microsoft365_mail_message.go
@@ -118,9 +118,7 @@ func listMicrosoft365MailMessages(ctx context.Context, d *plugin.QueryData, _ *p
 	if limit != nil && *limit < pageSize {
 		pageSize = *limit
 	}
-
-	pageSize32 := int32(pageSize)
-	input.Top = &pageSize32
+	input.Top = Int32(int32(pageSize))
 
 	// Check for query context and requests only for queried columns
 	givenColumns := d.QueryContext.Columns

--- a/microsoft365/table_microsoft365_my_calendar_event.go
+++ b/microsoft365/table_microsoft365_my_calendar_event.go
@@ -9,6 +9,7 @@ import (
 	msgraphcore "github.com/microsoftgraph/msgraph-sdk-go-core"
 	"github.com/microsoftgraph/msgraph-sdk-go/models"
 	"github.com/microsoftgraph/msgraph-sdk-go/users/item/calendarview"
+	"github.com/microsoftgraph/msgraph-sdk-go/users/item/events"
 )
 
 //// TABLE DEFINITION
@@ -67,6 +68,15 @@ func listMicrosoft365MyCalendarEvents(ctx context.Context, d *plugin.QueryData, 
 
 	input := &calendarview.CalendarViewRequestBuilderGetQueryParameters{}
 
+	// Minimum value is 1 (this function isn't run if "limit 0" is specified)
+	// Maximum value is unknown (tested up to 9999)
+	pageSize := int64(9999)
+	limit := d.QueryContext.Limit
+	if limit != nil && *limit < pageSize {
+		pageSize = *limit
+	}
+	input.Top = Int32(int32(pageSize))
+
 	var result models.EventCollectionResponseable
 
 	// Filter event using timestamp
@@ -124,7 +134,22 @@ func listMicrosoft365MyCalendarEvents(ctx context.Context, d *plugin.QueryData, 
 			return nil, errObj
 		}
 	} else {
-		result, err = client.UsersById(userID).Events().Get(ctx, nil)
+		input := &events.EventsRequestBuilderGetQueryParameters{}
+
+		// Minimum value is 1 (this function isn't run if "limit 0" is specified)
+		// Maximum value is unknown (tested up to 9999)
+		pageSize := int64(9999)
+		limit := d.QueryContext.Limit
+		if limit != nil && *limit < pageSize {
+			pageSize = *limit
+		}
+		input.Top = Int32(int32(pageSize))
+
+		options := &events.EventsRequestBuilderGetRequestConfiguration{
+			QueryParameters: input,
+		}
+
+		result, err = client.UsersById(userID).Events().Get(ctx, options)
 		if err != nil {
 			errObj := getErrorObject(err)
 			return nil, errObj

--- a/microsoft365/table_microsoft365_my_calendar_group.go
+++ b/microsoft365/table_microsoft365_my_calendar_group.go
@@ -7,6 +7,7 @@ import (
 
 	msgraphcore "github.com/microsoftgraph/msgraph-sdk-go-core"
 	"github.com/microsoftgraph/msgraph-sdk-go/models"
+	"github.com/microsoftgraph/msgraph-sdk-go/users/item/calendargroups"
 )
 
 //// TABLE DEFINITION
@@ -48,7 +49,22 @@ func listMicrosoft365MyCalendarGroups(ctx context.Context, d *plugin.QueryData, 
 	}
 	userID := userIDCached.(string)
 
-	result, err := client.UsersById(userID).CalendarGroups().Get(ctx, nil)
+	input := &calendargroups.CalendarGroupsRequestBuilderGetQueryParameters{}
+
+	// Minimum value is 1 (this function isn't run if "limit 0" is specified)
+	// Maximum value is unknown (tested up to 9999)
+	pageSize := int64(9999)
+	limit := d.QueryContext.Limit
+	if limit != nil && *limit < pageSize {
+		pageSize = *limit
+	}
+	input.Top = Int32(int32(pageSize))
+
+	options := &calendargroups.CalendarGroupsRequestBuilderGetRequestConfiguration{
+		QueryParameters: input,
+	}
+
+	result, err := client.UsersById(userID).CalendarGroups().Get(ctx, options)
 	if err != nil {
 		errObj := getErrorObject(err)
 		return nil, errObj

--- a/microsoft365/table_microsoft365_my_contact.go
+++ b/microsoft365/table_microsoft365_my_contact.go
@@ -62,9 +62,7 @@ func listMicrosoft365MyContacts(ctx context.Context, d *plugin.QueryData, h *plu
 	if limit != nil && *limit < pageSize {
 		pageSize = *limit
 	}
-
-	pageSize32 := int32(pageSize)
-	input.Top = &pageSize32
+	input.Top = Int32(int32(pageSize))
 
 	options := &contacts.ContactsRequestBuilderGetRequestConfiguration{
 		QueryParameters: input,

--- a/microsoft365/table_microsoft365_my_drive.go
+++ b/microsoft365/table_microsoft365_my_drive.go
@@ -52,6 +52,15 @@ func listMicrosoft365MyDrives(ctx context.Context, d *plugin.QueryData, h *plugi
 
 	input := &drives.DrivesRequestBuilderGetQueryParameters{}
 
+	// Minimum value is 1 (this function isn't run if "limit 0" is specified)
+	// Maximum value is unknown (tested up to 9999)
+	pageSize := int64(9999)
+	limit := d.QueryContext.Limit
+	if limit != nil && *limit < pageSize {
+		pageSize = *limit
+	}
+	input.Top = Int32(int32(pageSize))
+
 	var queryFilter string
 	equalQuals := d.KeyColumnQuals
 	filter := buildDriveQueryFilter(equalQuals)

--- a/microsoft365/table_microsoft365_my_mail_message.go
+++ b/microsoft365/table_microsoft365_my_mail_message.go
@@ -74,9 +74,7 @@ func listMicrosoft365MyMailMessages(ctx context.Context, d *plugin.QueryData, h 
 	if limit != nil && *limit < pageSize {
 		pageSize = *limit
 	}
-
-	pageSize32 := int32(pageSize)
-	input.Top = &pageSize32
+	input.Top = Int32(int32(pageSize))
 
 	// Check for query context and requests only for queried columns
 	givenColumns := d.QueryContext.Columns

--- a/microsoft365/table_microsoft365_organization_contact.go
+++ b/microsoft365/table_microsoft365_organization_contact.go
@@ -117,9 +117,7 @@ func listMicrosoft365OrganizationContacts(ctx context.Context, d *plugin.QueryDa
 	if limit != nil && *limit < pageSize {
 		pageSize = *limit
 	}
-
-	pageSize32 := int32(pageSize)
-	input.Top = &pageSize32
+	input.Top = Int32(int32(pageSize))
 
 	options := &contacts.ContactsRequestBuilderGetRequestConfiguration{
 		QueryParameters: input,

--- a/microsoft365/table_microsoft365_team.go
+++ b/microsoft365/table_microsoft365_team.go
@@ -84,9 +84,7 @@ func listMicrosoft365Teams(ctx context.Context, d *plugin.QueryData, _ *plugin.H
 	if limit != nil && *limit < pageSize {
 		pageSize = *limit
 	}
-
-	pageSize32 := int32(pageSize)
-	input.Top = &pageSize32
+	input.Top = Int32(int32(pageSize))
 
 	// To get a list of all groups in the organization that have teams, get a list of all groups,
 	// and then in code find the ones that have a resourceProvisioningOptions property that contains "Team".

--- a/microsoft365/table_microsoft365_team_member.go
+++ b/microsoft365/table_microsoft365_team_member.go
@@ -54,6 +54,18 @@ func listMicrosoft365TeamMembers(ctx context.Context, d *plugin.QueryData, h *pl
 		Count: &includeCount,
 	}
 
+	// Restrict the limit value to be passed in the query parameter which is not between 1 and 999, otherwise API will throw an error as follow
+	// unexpected status 400 with OData error: Request_UnsupportedQuery: Invalid page size specified: '1000'. Must be between 1 and 999 inclusive.
+
+	// Minimum value is 1 (this function isn't run if "limit 0" is specified)
+	// Maximum value is 999
+	pageSize := int64(999)
+	limit := d.QueryContext.Limit
+	if limit != nil && *limit < pageSize {
+		pageSize = *limit
+	}
+	requestParameters.Top = Int32(int32(pageSize))
+
 	config := &members.MembersRequestBuilderGetRequestConfiguration{
 		Headers:         headers,
 		QueryParameters: requestParameters,

--- a/microsoft365/utils.go
+++ b/microsoft365/utils.go
@@ -105,3 +105,8 @@ func getUserID(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateData) 
 
 	return nil, nil
 }
+
+// Int32 returns a pointer to the int32 value passed in.
+func Int32(v int32) *int32 {
+	return &v
+}


### PR DESCRIPTION
# Example query results
<details>
  <summary>Results</summary>
  
```
Add example SQL query results here (please include the input queries as well)
```
</details>
