### PR TITLE
Update plugin to return full error by default

### DIFF
--- a/microsoft365/errors.go
+++ b/microsoft365/errors.go
@@ -26,22 +26,12 @@ func (m *RequestError) Error() string {
 
 // Returns the error object
 func getErrorObject(err error) *RequestError {
-	if oDataError, ok := err.(*odataerrors.ODataError); ok {
-		if terr := oDataError.GetError(); terr != nil {
-			return &RequestError{
-				Code:    *terr.GetCode(),
-				Message: *terr.GetMessage(),
-			}
-		}
-	}
-
 	switch err := err.(type) {
 	case *odataerrors.ODataError:
-		if terr := err.GetError(); terr != nil {
-			return &RequestError{
-				Code:    *terr.GetCode(),
-				Message: *terr.GetMessage(),
-			}
+		terr := err.GetError()
+		return &RequestError{
+			Code:    *terr.GetCode(),
+			Message: *terr.GetMessage(),
 		}
 	case *azidentity.AuthenticationFailedError:
 		return &RequestError{
@@ -55,8 +45,6 @@ func getErrorObject(err error) *RequestError {
 			Message: err.Error(),
 		}
 	}
-
-	return nil
 }
 
 func isIgnorableErrorPredicate(ignoreErrorCodes []string) plugin.ErrorPredicateWithContext {

--- a/microsoft365/errors.go
+++ b/microsoft365/errors.go
@@ -22,6 +22,7 @@ func (m *RequestError) Error() string {
 	return string(errStr)
 }
 
+// Returns the error object
 func getErrorObject(err error) *RequestError {
 	if oDataError, ok := err.(*odataerrors.ODataError); ok {
 		if terr := oDataError.GetError(); terr != nil {
@@ -32,7 +33,11 @@ func getErrorObject(err error) *RequestError {
 		}
 	}
 
-	return nil
+	// If the type of error is other than ODataError
+	// return the exact error
+	return &RequestError{
+		Message: err.Error(),
+	}
 }
 
 func isIgnorableErrorPredicate(ignoreErrorCodes []string) plugin.ErrorPredicateWithContext {

--- a/microsoft365/errors.go
+++ b/microsoft365/errors.go
@@ -3,8 +3,10 @@ package microsoft365
 import (
 	"context"
 	"encoding/json"
+	"strconv"
 	"strings"
 
+	"github.com/Azure/azure-sdk-for-go/sdk/azidentity"
 	"github.com/microsoftgraph/msgraph-sdk-go/models/odataerrors"
 	"github.com/turbot/steampipe-plugin-sdk/v4/plugin"
 )
@@ -33,11 +35,28 @@ func getErrorObject(err error) *RequestError {
 		}
 	}
 
-	// If the type of error is other than ODataError
-	// return the exact error
-	return &RequestError{
-		Message: err.Error(),
+	switch err := err.(type) {
+	case *odataerrors.ODataError:
+		if terr := err.GetError(); terr != nil {
+			return &RequestError{
+				Code:    *terr.GetCode(),
+				Message: *terr.GetMessage(),
+			}
+		}
+	case *azidentity.AuthenticationFailedError:
+		return &RequestError{
+			Code:    strconv.Itoa(err.RawResponse.StatusCode),
+			Message: err.Error(),
+		}
+	default:
+		// If the error type is unknown
+		// return the exact error
+		return &RequestError{
+			Message: err.Error(),
+		}
 	}
+
+	return nil
 }
 
 func isIgnorableErrorPredicate(ignoreErrorCodes []string) plugin.ErrorPredicateWithContext {


### PR DESCRIPTION
# Example query results
<details>
  <summary>Results</summary>
  
```
Add example SQL query results here (please include the input queries as well)
```
</details>
